### PR TITLE
TED-849 reconfigure 'soft-delete a team' endpoint

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -18,3 +18,13 @@ Error Code | Meaning
 429 | Too Many Requests -- You're requesting too many resources! Slow down!
 500 | Internal Server Error -- We had a problem with our server. Try again later.
 503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later.
+
+---
+### Miscellaneous
+
+**Help with JSON API Requests**
+
+* <a href="http://jsonapi.org/format/#crud-creating">Creating a Resource</a>
+* <a href="http://jsonapi.org/format/#crud-updating">Updating a Resource</a>
+* <a href="http://jsonapi.org/format/#crud-updating-relationships">Updating Resource Relationships</a>
+* <a href="http://jsonapi.org/format/#crud-deleting">Deleting a Resource</a>

--- a/source/includes/team_integrations/_delete_team.md
+++ b/source/includes/team_integrations/_delete_team.md
@@ -1,8 +1,10 @@
 # SOFT-DELETE A TEAM
 
-**PATCH `/api/team_edition/teams/:team_id/toggle_deleted`**
+**DELETE `/api/team_edition/teams/:team_id/delete_team`**
 
 This endpoint soft-deletes a team (sets the `deleted` field value to `true` on the team record). At present this endpoint cannot undo a soft-delete.
+
+Important: Partners should use their own `team_id` in the URL.
 
 ## Requests
 
@@ -19,8 +21,8 @@ This endpoint soft-deletes a team (sets the `deleted` field value to `true` on t
 _cURL_
 
 ```shell
-curl --request PATCH \
-  --url http://qa.ncsasports.org/api/team_edition/teams/9/toggle_deleted \
+curl --request DELETE \
+  --url http://qa.ncsasports.org/api/team_edition/teams/9/delete_team \
   --header 'content-type: application/vnd.api+json' \
   --header 'session-token: eyJ0eXAiOiJKV1QiLCiJ9...' \
 ```
@@ -32,11 +34,11 @@ _Ruby Net::Http_
 require 'URI'
 require 'net/http'
 
-url = URI("http://qa.ncsasports.org/api/team_edition/teams/9/toggle_deleted")
+url = URI("http://qa.ncsasports.org/api/team_edition/teams/9/delete_team")
 
 http = Net::HTTP.new(url.host, url.port)
 
-request = Net::HTTP::Patch.new(url)
+request = Net::HTTP::Delete.new(url)
 request['session-token'] = 'eyJ0eXAiOiJKV1QiLCiJ9...'
 request['content-type'] = 'application/vnd.api+json'
 
@@ -83,4 +85,4 @@ puts response.read_body
 
 ## Errors & Statuses
 
-* For errors, see relevant spec files to flesh out this section.
+404: Team Not Found

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -4,8 +4,6 @@ title: Team Edition API Docs
 language_tabs:
 
 toc_footers:
-  - <h2>Tips</h2>
-  - The often-referenced `session-token` header can be found stored in a cookie named `team_rms_session`.<br>
   - <h2>Helpful Documentation</h2><br>
   - <strong><a href='http://jsonapi.org'>JSON API Documentation</a></strong>
   - <strong><a href="http://jsonapi.org/format/#crud-creating">Creating a Resource</a></strong>
@@ -15,16 +13,17 @@ toc_footers:
   - Documentation Powered by <a href='https://github.com/tripit/slate'>Slate</a>
 
 includes:
-  - errors
+  - sessions/create
+  - sessions/destroy
   - athletes/create
   - athletes/create_bulk
   - athletes/index
   - athletes/refresh_athletes
   - athletes/show
-  - athletes/get_profile_url
+
   - athletes/profile
   - athletes/activity
-  - athletes/preferences
+
   - athletes/get_athlete_teams
   - athletes/update_athlete_teams
   - athlete_integrations/recommendation
@@ -56,14 +55,13 @@ includes:
   - pricing_tiers/index
   - pricing_tiers/tier_sports
   - public_information/organization
-  - sessions/create
-  - sessions/destroy
   - team_integrations/toggle_active
-  - team_integrations/toggle_deleted
+  - team_integrations/delete_team
   - teams/index
   - teams/create
   - teams/show
   - teams/update
+  - errors
 
 search: true
 ---
@@ -74,138 +72,9 @@ Welcome to the Team Edition API! You can use our API to access NCSA Team Edition
 
 You can view code examples in the dark area to the right.
 
+Production URL: `http://www.ncsasports.org`
 
+Staging URL: `http://qa.ncsasports.org`
 
----
-
-## Slate Markdown Syntax
-
-```markdown
-This is a reference for the Markdown syntax used in Slate.
-
-### Headers
-
-For headers:
-
-    # Level 1 Header
-    ## Level 2 Header
-    ### Level 3 Header
-
-Note that only level 1 and 2 headers will appear in the table of contents.
-
-### Paragraph Text
-
-For normal text, just type your paragraph on a single line.
-
-    This is some paragraph text. Exciting, no?
-
-Make sure the lines above and below your paragraph are empty.
-
-### Code Samples
-
-For code samples:
-
-```
-  ```ruby
-  # This is some Ruby code!
-  ```
-
-  ```python
-  # This is some Python code!
-  ```
-```
-
-Code samples will appear in the dark area to the right of the main text. We recommend positioning code samples right under headers in your markdown file.
-
-For the full list of supported languages, see [rouge](http://rouge.jneen.net/).
-
-### Code Annotations
-
-For code annotations:
-
-    > This is a code annotation. It will appear in the area to the right, next to the code samples.
-
-Code annotations are essentially the same thing as paragraphs, but they'll appear in the area to the right along with your code samples.
-
-### Tables
-
-Slate uses PHP Markdown Extra style tables:
-
-```markdown
-Table Header 1 | Table Header 2 | Table Header 3
--------------- | -------------- | --------------
-Row 1 col 1 | Row 1 col 2 | Row 1 col 3
-Row 2 col 1 | Row 2 col 2 | Row 2 col 3
-'```'
-
-Note that the pipes do not need to line up with each other on each line.
-
-If you don't like that syntax, feel free to use normal html `<table>`s directly in your markdown.
-
-### Formatted Text
-
-    This text is **bold**, this is *italic*, this is an `inline code block`.
-
-You can use those formatting rules in code annotations, tables, paragraphs, lists, wherever.
-
-### Lists
-
-    1. This
-    2. Is
-    3. An
-    4. Ordered
-    5. List
-
-    * This
-    * Is
-    * A
-    * Bullet
-    * List
-
-### Links
-
-    This is an [internal link](#error-code-definitions), this is an [external link](http://google.com).
-
-### Notes and Warnings
-
-You can add little highlighted warnings and notes with just a little HTML embedded in your markdown document:
-
-    <aside class="notice">
-    You must replace `meowmeowmeow` with your personal API key.
-    </aside>
-
-Use `class="notice"` for blue notes, `class="warning"` for red warnings, and `class="success"` for green notes.
-
-### Need Help?
-
-If you have trouble with any of the syntax, or if it's confusing, let us know by filing an issue. Thanks!
-
-```
-
-
-
-
-### Miscellaneous
-
-**Help with JSON API Requests**
-
-* <a href="http://jsonapi.org/format/#crud-creating">Creating a Resource</a>
-* <a href="http://jsonapi.org/format/#crud-updating">Updating a Resource</a>
-* <a href="http://jsonapi.org/format/#crud-updating-relationships">Updating Resource Relationships</a>
-* <a href="http://jsonapi.org/format/#crud-deleting">Deleting a Resource</a>
-
-
-Error Code | Meaning
----------- | -------
-400 | Bad Request -- Your request sucks
-401 | Unauthorized -- Your API key is wrong
-403 | Forbidden -- The resource requested is hidden for administrators only
-404 | Not Found -- The specified resource could not be found
-405 | Method Not Allowed -- You tried to access a resource with an invalid method
-406 | Not Acceptable -- You requested a format that isn't json
-410 | Gone -- The resource requested has been removed from our servers
-418 | I'm a teapot
-429 | Too Many Requests -- You're requesting too many resources! Slow down!
-500 | Internal Server Error -- We had a problem with our server. Try again later.
-503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later.
-
+### Tips
+The oft-referenced `session-token` header can be found stored in a cookie named `team_rms_session`.<br>


### PR DESCRIPTION
[Jira Ticket](https://ncsasports.atlassian.net/browse/TED-849)
[Team Edition Service PR](https://github.com/NCSAAthleticRecruiting/team_edition_service/pull/298)

- Updated the entry for the `Soft-Delete A Team` endpoint that I changed.
- Took out some unnecessary Slate documentation at the top of the page
- Added the URLs and Tips to the Introduction section.